### PR TITLE
Added large number of seconds to read in tick file

### DIFF
--- a/NCDFile.cs
+++ b/NCDFile.cs
@@ -69,6 +69,7 @@ namespace RespondClient.DomiKnow.NinjaTrader
         Time4 = 3,                      // x.....011
         Time8 = 4,                      // x.....100
         Time1Secs = 5,                  // x.....101
+        Time1SecsL = 6,                 // x.....110
         Ask = 8,                        // x..xx1...  
         DefaultSpreadX2 = 16,           // x..x1x...  
         DefaultSpreadX3 = 32,           // x..1xx...  
@@ -284,6 +285,11 @@ namespace RespondClient.DomiKnow.NinjaTrader
             if (mask1.HasOption(TickMask1Flags.Time1Secs))
             {
                 timeDelta = _br.ReadByte();
+                barDateTime = _lastDateTime.AddTicks((long)(timeDelta * 10000000));
+            }
+            else if (mask1.HasOption(TickMask1Flags.Time1SecsL))
+            {
+                timeDelta = _br.ReadUInt16BE();
                 barDateTime = _lastDateTime.AddTicks((long)(timeDelta * 10000000));
             }
             else if (mask1.HasOption(TickMask1Flags.Time8))


### PR DESCRIPTION
Added large number of seconds to read in tick file - fixing bug with sparse db files.
In these cases, the second count is larger than one byte and 2 bytes read is needed.
(I didn't check whether it is an issue with minutes file) 